### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/did-you-mean/index.html
+++ b/src/did-you-mean/index.html
@@ -1,5 +1,5 @@
 <yield>
-  <gb-list items="{ state.didYouMeans }">
-    <gb-link on-click="{ item.onClick }" _consumes="item">{ $item.value }</gb-link>
+  <gb-list items="{state.didYouMeans}">
+    <gb-link on-click="{item.onClick}" _consumes="item">{$item.value}</gb-link>
   </gb-list>
 </yield>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.